### PR TITLE
Fix freemius-update shell-quoting crash; move PHP to a script file

### DIFF
--- a/.github/scripts/freemius-get-package.php
+++ b/.github/scripts/freemius-get-package.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * Fetch the latest Freemius version and a signed download URL for a plugin.
+ *
+ * Expects the following environment variables:
+ *   FREEMIUS_USER_ID, FREEMIUS_PUBLIC_KEY, FREEMIUS_SECRET_KEY,
+ *   FREEMIUS_LICENSE_KEY, FREEMIUS_PLUGIN_ID, FREEMIUS_SITE_URL
+ *
+ * Writes `version`, `download_url` and `install_id` to $GITHUB_OUTPUT.
+ */
+
+$user_id     = getenv("FREEMIUS_USER_ID");
+$public_key  = getenv("FREEMIUS_PUBLIC_KEY");
+$secret_key  = getenv("FREEMIUS_SECRET_KEY");
+$license_key = getenv("FREEMIUS_LICENSE_KEY");
+$plugin_id   = getenv("FREEMIUS_PLUGIN_ID");
+
+function base64url_encode($input) {
+    return str_replace("=", "", strtr(base64_encode($input), "+/", "-_"));
+}
+
+function freemius_api($scope, $scope_id, $public, $secret, $path, $method = "GET", $body = null) {
+    $bases = [
+        "user"    => "/users/$scope_id",
+        "install" => "/installs/$scope_id",
+    ];
+    $resource = "/v1" . $bases[$scope] . "/" . ltrim($path, "/");
+
+    $date         = gmdate("r");
+    $content_md5  = "";
+    $content_type = "";
+    if (in_array($method, ["POST", "PUT"]) && $body) {
+        $content_type = "application/json";
+        $content_md5  = md5($body);
+    }
+
+    $string_to_sign = implode("\n", [$method, $content_md5, $content_type, $date, $resource]);
+    $sig  = base64url_encode(hash_hmac("sha256", $string_to_sign, $secret));
+    $auth = "FS $scope_id:$public:$sig";
+
+    $headers = ["Authorization: $auth", "Date: $date"];
+    if ($body) $headers[] = "Content-Type: application/json";
+
+    $ch = curl_init("https://api.freemius.com" . $resource);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+    if ($body) curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+    $result = curl_exec($ch);
+    $code   = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    return ["code" => $code, "body" => json_decode($result)];
+}
+
+function freemius_signed_url($scope_id, $public, $secret, $resource) {
+    $date = gmdate("r");
+    $string_to_sign = implode("\n", ["GET", "", "", $date, $resource]);
+    $sig  = base64url_encode(hash_hmac("sha256", $string_to_sign, $secret));
+    $auth = "FS $scope_id:$public:$sig";
+
+    return "https://api.freemius.com" . $resource .
+        "?is_premium=true" .
+        "&authorization=" . urlencode($auth) .
+        "&auth_date=" . urlencode($date);
+}
+
+// 1. Get latest version from tags
+$res = freemius_api("user", $user_id, $public_key, $secret_key, "plugins/$plugin_id/tags.json");
+if ($res["code"] !== 200 || !isset($res["body"]->tags[0])) {
+    fwrite(STDERR, "Failed to fetch tags\n");
+    exit(1);
+}
+$latest = $res["body"]->tags[0];
+$version = $latest->version;
+echo "Latest version: $version\n";
+
+// 2. Delete any pre-existing installs for this URL so we do not accumulate
+//    one record per CI run. Freemius does not allow updating a stale install
+//    without its (unstored) credentials, so we delete and recreate.
+$site_url = getenv("FREEMIUS_SITE_URL");
+$res = freemius_api("user", $user_id, $public_key, $secret_key,
+    "plugins/$plugin_id/installs.json?search=" . urlencode($site_url));
+if ($res["code"] === 200 && !empty($res["body"]->installs)) {
+    $needle = rtrim(preg_replace("#^https?://#", "", $site_url), "/");
+    foreach ($res["body"]->installs as $i) {
+        $haystack = rtrim(preg_replace("#^https?://#", "", $i->url ?? ""), "/");
+        if ($haystack !== $needle) continue;
+        $del = freemius_api("user", $user_id, $public_key, $secret_key,
+            "plugins/$plugin_id/installs/{$i->id}.json", "DELETE");
+        if (!in_array($del["code"], [200, 204])) {
+            fwrite(STDERR, "Warning: failed to delete stale install {$i->id}: " . json_encode($del["body"]) . "\n");
+        } else {
+            echo "Deleted stale install: {$i->id}\n";
+        }
+    }
+}
+
+// 3. Register an install to get download credentials
+$install_data = json_encode([
+    "url"         => $site_url,
+    "title"       => "CI",
+    "version"     => $version,
+    "license_key" => $license_key,
+    "is_premium"  => true,
+    "language"    => "en-US",
+]);
+
+$res = freemius_api("user", $user_id, $public_key, $secret_key,
+    "plugins/$plugin_id/installs.json", "POST", $install_data);
+
+if (!in_array($res["code"], [200, 201]) || !isset($res["body"]->id)) {
+    fwrite(STDERR, "Failed to register install: " . json_encode($res["body"]) . "\n");
+    exit(1);
+}
+
+$install_id = $res["body"]->id;
+$install_pk = $res["body"]->public_key;
+$install_sk = $res["body"]->secret_key;
+echo "Install registered: $install_id\n";
+
+// 4. Generate signed download URL
+$download_url = freemius_signed_url(
+    $install_id, $install_pk, $install_sk,
+    "/v1/installs/$install_id/updates/latest.zip"
+);
+
+// 5. Write outputs
+$output = getenv("GITHUB_OUTPUT");
+file_put_contents($output, "version=$version\n", FILE_APPEND);
+file_put_contents($output, "download_url=$download_url\n", FILE_APPEND);
+file_put_contents($output, "install_id=$install_id\n", FILE_APPEND);

--- a/.github/workflows/freemius-update.yml
+++ b/.github/workflows/freemius-update.yml
@@ -41,6 +41,13 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Checkout action scripts
+        uses: actions/checkout@v4
+        with:
+          repository: generoi/github-action-update-plugins
+          ref: master
+          path: .github-action-update-plugins
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
 
@@ -53,131 +60,7 @@ jobs:
           FREEMIUS_LICENSE_KEY: ${{ secrets.FREEMIUS_LICENSE_KEY }}
           FREEMIUS_PLUGIN_ID: ${{ inputs.plugin_id }}
           FREEMIUS_SITE_URL: ${{ inputs.site_url }}
-        run: |
-          php -r '
-            $user_id    = getenv("FREEMIUS_USER_ID");
-            $public_key = getenv("FREEMIUS_PUBLIC_KEY");
-            $secret_key = getenv("FREEMIUS_SECRET_KEY");
-            $license_key = getenv("FREEMIUS_LICENSE_KEY");
-            $plugin_id  = getenv("FREEMIUS_PLUGIN_ID");
-
-            function base64url_encode($input) {
-                return str_replace("=", "", strtr(base64_encode($input), "+/", "-_"));
-            }
-
-            function freemius_api($scope, $scope_id, $public, $secret, $path, $method = "GET", $body = null) {
-                $bases = [
-                    "user"    => "/users/$scope_id",
-                    "install" => "/installs/$scope_id",
-                ];
-                $resource = "/v1" . $bases[$scope] . "/" . ltrim($path, "/");
-
-                $date         = gmdate("r");
-                $content_md5  = "";
-                $content_type = "";
-                if (in_array($method, ["POST", "PUT"]) && $body) {
-                    $content_type = "application/json";
-                    $content_md5  = md5($body);
-                }
-
-                $string_to_sign = implode("\n", [$method, $content_md5, $content_type, $date, $resource]);
-                $sig  = base64url_encode(hash_hmac("sha256", $string_to_sign, $secret));
-                $auth = "FS $scope_id:$public:$sig";
-
-                $headers = ["Authorization: $auth", "Date: $date"];
-                if ($body) $headers[] = "Content-Type: application/json";
-
-                $ch = curl_init("https://api.freemius.com" . $resource);
-                curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-                curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
-                curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
-                if ($body) curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
-                curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-                $result = curl_exec($ch);
-                $code   = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-                curl_close($ch);
-
-                return ["code" => $code, "body" => json_decode($result)];
-            }
-
-            function freemius_signed_url($scope_id, $public, $secret, $resource) {
-                $date = gmdate("r");
-                $string_to_sign = implode("\n", ["GET", "", "", $date, $resource]);
-                $sig  = base64url_encode(hash_hmac("sha256", $string_to_sign, $secret));
-                $auth = "FS $scope_id:$public:$sig";
-
-                return "https://api.freemius.com" . $resource .
-                    "?is_premium=true" .
-                    "&authorization=" . urlencode($auth) .
-                    "&auth_date=" . urlencode($date);
-            }
-
-            // 1. Get latest version from tags
-            $res = freemius_api("user", $user_id, $public_key, $secret_key, "plugins/$plugin_id/tags.json");
-            if ($res["code"] !== 200 || !isset($res["body"]->tags[0])) {
-                fwrite(STDERR, "Failed to fetch tags\n");
-                exit(1);
-            }
-            $latest = $res["body"]->tags[0];
-            $version = $latest->version;
-            echo "Latest version: $version\n";
-
-            // 2. Delete any pre-existing installs for this URL so we don't accumulate
-            //    one record per CI run. Freemius doesn't allow updating a stale install
-            //    without its (unstored) credentials, so we delete and recreate.
-            $site_url = getenv("FREEMIUS_SITE_URL");
-            $res = freemius_api("user", $user_id, $public_key, $secret_key,
-                "plugins/$plugin_id/installs.json?search=" . urlencode($site_url));
-            if ($res["code"] === 200 && !empty($res["body"]->installs)) {
-                $needle = rtrim(preg_replace("#^https?://#", "", $site_url), "/");
-                foreach ($res["body"]->installs as $i) {
-                    $haystack = rtrim(preg_replace("#^https?://#", "", $i->url ?? ""), "/");
-                    if ($haystack !== $needle) continue;
-                    $del = freemius_api("user", $user_id, $public_key, $secret_key,
-                        "plugins/$plugin_id/installs/{$i->id}.json", "DELETE");
-                    if (!in_array($del["code"], [200, 204])) {
-                        fwrite(STDERR, "Warning: failed to delete stale install {$i->id}: " . json_encode($del["body"]) . "\n");
-                    } else {
-                        echo "Deleted stale install: {$i->id}\n";
-                    }
-                }
-            }
-
-            // 3. Register an install to get download credentials
-            $install_data = json_encode([
-                "url"         => $site_url,
-                "title"       => "CI",
-                "version"     => $version,
-                "license_key" => $license_key,
-                "is_premium"  => true,
-                "language"    => "en-US",
-            ]);
-
-            $res = freemius_api("user", $user_id, $public_key, $secret_key,
-                "plugins/$plugin_id/installs.json", "POST", $install_data);
-
-            if (!in_array($res["code"], [200, 201]) || !isset($res["body"]->id)) {
-                fwrite(STDERR, "Failed to register install: " . json_encode($res["body"]) . "\n");
-                exit(1);
-            }
-
-            $install_id = $res["body"]->id;
-            $install_pk = $res["body"]->public_key;
-            $install_sk = $res["body"]->secret_key;
-            echo "Install registered: $install_id\n";
-
-            // 4. Generate signed download URL
-            $download_url = freemius_signed_url(
-                $install_id, $install_pk, $install_sk,
-                "/v1/installs/$install_id/updates/latest.zip"
-            );
-
-            // 5. Write outputs
-            $output = getenv("GITHUB_OUTPUT");
-            file_put_contents($output, "version=$version\n", FILE_APPEND);
-            file_put_contents($output, "download_url=$download_url\n", FILE_APPEND);
-            file_put_contents($output, "install_id=$install_id\n", FILE_APPEND);
-          '
+        run: php .github-action-update-plugins/.github/scripts/freemius-get-package.php
 
       - name: Log response
         run: |


### PR DESCRIPTION
## What failed

The Freemius reusable workflow crashed in the *Fetch latest version and download URL* step:

```
Latest version: 1.0.2
.../...sh: line 70: //: Is a directory
##[error]Process completed with exit code 126.
```

([example run](https://github.com/generoi/tableberg-pro/actions/runs/27118517456/job/80030237208))

## Cause

The entire PHP program was passed to `php -r '...'` wrapped in a **single-quoted** shell string. Two PHP comments contained apostrophes:

```php
// ... so we don't accumulate
// ... Freemius doesn't allow updating a stale install
```

Each `'` toggles bash's single-quote state, so after `don't` bash was *outside* the quotes and treated the following `//` comment lines as commands → `//: Is a directory` (exit 126). The `Latest version` line printed because bash concatenates the quoted fragments before the break.

## Fix

- Move the PHP into `.github/scripts/freemius-get-package.php` (matches the existing `wccom-get-package.php` convention) and run the file — no shell quoting involved, plus real PHP linting (`php -l` passes).
- The reusable workflow checks out this action repo into a subpath so the script is on disk at runtime (the primary `actions/checkout` brings in the *caller's* repo, not this one).

> Note: `edd-update.yml` and `gravityforms-update.yml` still inline `php -r` and carry the same latent risk — out of scope here, but worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)