### PR TITLE
Improve WooCommerce.com package fetch failure messages

### DIFF
--- a/.github/actions/wccom-package/action.yml
+++ b/.github/actions/wccom-package/action.yml
@@ -21,10 +21,17 @@ runs:
       id: wccom-package
       shell: bash
       run: |
+        # Capture the package JSON separately so a script failure surfaces its
+        # stderr and a clean exit code, instead of leaving an unterminated
+        # heredoc in $GITHUB_OUTPUT ("Matching delimiter not found 'EOF'").
+        if ! response=$(php "$GITHUB_ACTION_PATH/../../scripts/wccom-get-package.php"); then
+          echo "::error::Failed to fetch package from WooCommerce.com (see error above)."
+          exit 1
+        fi
+
         {
           echo 'REMOTE_RESPONSE<<EOF'
-          php $GITHUB_ACTION_PATH/../../scripts/wccom-get-package.php
-          echo -e "\n"
+          echo "$response"
           echo 'EOF'
         } >> "$GITHUB_OUTPUT"
       env:

--- a/.github/scripts/wccom-get-package.php
+++ b/.github/scripts/wccom-get-package.php
@@ -6,9 +6,20 @@
 
 $productSlug = getenv('PRODUCT_SLUG');
 
-function doRequest(string $endpoint, string $method = 'GET', string $body = null) {
+function fail(string $message): void {
+  // Write to stderr so it shows up in the workflow log instead of being
+  // redirected into $GITHUB_OUTPUT together with the package JSON.
+  fwrite(STDERR, $message . PHP_EOL);
+  exit(1);
+}
+
+function doRequest(string $endpoint, string $method = 'GET', ?string $body = null) {
   $accessToken = getenv('ACCESS_TOKEN');
   $accessTokenSecret = getenv('ACCESS_TOKEN_SECRET');
+
+  if (! $accessToken || ! $accessTokenSecret) {
+    fail('Missing ACCESS_TOKEN and/or ACCESS_TOKEN_SECRET. Check the repository/organization secrets.');
+  }
 
   $data = [
     'host' => parse_url($endpoint, PHP_URL_HOST),
@@ -22,15 +33,54 @@ function doRequest(string $endpoint, string $method = 'GET', string $body = null
 
   $signature = hash_hmac('sha256', json_encode($data), $accessTokenSecret);
   $query = http_build_query(['token' => $accessToken, 'signature' => $signature]);
-  $response = exec(sprintf(
-    'curl -s -X %s %s -H %s -H %s %s',
+
+  // -w appends the HTTP status code so we can distinguish auth/server errors
+  // from an empty body. -s silences progress, output is the body + status.
+  $command = sprintf(
+    'curl -s -w "\n%%{http_code}" -X %s %s -H %s -H %s %s',
     $method,
     $body ? '--data ' . escapeshellarg($body) : '',
     escapeshellarg('Authorization: Bearer ' . $accessToken),
     escapeshellarg('X-Woo-Signature: ' . $signature),
-    escapeshellarg($endpoint.'?'.$query),
-  ));
-  return json_decode($response);
+    escapeshellarg($endpoint . '?' . $query),
+  );
+
+  $output = [];
+  $exitCode = 0;
+  exec($command, $output, $exitCode);
+
+  if ($exitCode !== 0) {
+    fail(sprintf('curl request to %s failed with exit code %d.', $endpoint, $exitCode));
+  }
+
+  $httpStatus = (int) array_pop($output);
+  $rawBody = implode("\n", $output);
+
+  if ($httpStatus < 200 || $httpStatus >= 300) {
+    fail(sprintf(
+      'Request to %s returned HTTP %d. Response: %s',
+      $endpoint,
+      $httpStatus,
+      $rawBody !== '' ? $rawBody : '(empty body)',
+    ));
+  }
+
+  $decoded = json_decode($rawBody);
+
+  if (json_last_error() !== JSON_ERROR_NONE) {
+    fail(sprintf(
+      'Failed to decode JSON response from %s: %s. Response: %s',
+      $endpoint,
+      json_last_error_msg(),
+      $rawBody !== '' ? $rawBody : '(empty body)',
+    ));
+  }
+
+  return $decoded;
+}
+
+if (! $productSlug) {
+  fail('Missing PRODUCT_SLUG. Pass the plugin slug via the action `slug` input.');
 }
 
 $subscriptions = doRequest(
@@ -45,8 +95,19 @@ $subscription = array_reduce(
 );
 
 if (! $subscription) {
-  echo 'Cannot find subscription'.PHP_EOL;
-  exit(1);
+  $availableSlugs = array_filter(array_map(
+    fn ($subscription) => $subscription->zip_slug ?? null,
+    (array) $subscriptions,
+  ));
+  sort($availableSlugs);
+
+  fail(sprintf(
+    "Cannot find subscription for slug '%s'.%s",
+    $productSlug,
+    $availableSlugs
+      ? ' Available slugs on this account: ' . implode(', ', $availableSlugs)
+      : ' No subscriptions were returned for this account (check the access token and that the subscription is active).',
+  ));
 }
 
 $productId = $subscription->product_id;
@@ -58,14 +119,18 @@ $payload = [
   ],
 ];
 
-$body = json_encode([
-  'products' => $payload,
-]);
-
 $response = doRequest(
   endpoint: 'https://woocommerce.com/wp-json/helper/1.0/update-check',
   method: 'POST',
   body: json_encode(['products' => $payload]),
 );
+
+if (! isset($response->{$productId})) {
+  fail(sprintf(
+    'update-check did not return package data for product ID %s. Response: %s',
+    $productId,
+    json_encode($response),
+  ));
+}
 
 echo json_encode($response->{$productId});


### PR DESCRIPTION
## Problem

The `Update plugin` job for plugins using `wccom-update.yml` was failing with a misleading error ([example run](https://github.com/generoi/woocommerce-cost-of-goods/actions/runs/27118506110/job/80030203961)):

```
##[error]Process completed with exit code 1.
##[error]Unable to process file command 'output' successfully.
##[error]Invalid value. Matching delimiter not found 'EOF'
```

The real cause was hidden:

1. `wccom-get-package.php` exited 1 (e.g. *"Cannot find subscription"*).
2. The script wrote that message to **stdout**, which the wrapper redirected into `$GITHUB_OUTPUT` — so it never appeared in the log.
3. `set -e` aborted the heredoc before its closing `EOF`, producing the confusing "Matching delimiter not found" error that masked the actual failure.

## Changes

**`.github/scripts/wccom-get-package.php`**
- Route all errors to **stderr** via a `fail()` helper so they show in the workflow log.
- Add specific diagnostics:
  - Missing `ACCESS_TOKEN` / `ACCESS_TOKEN_SECRET` or `PRODUCT_SLUG`.
  - `curl` non-zero exit code.
  - Non-2xx HTTP status (auth/server errors), with the response body.
  - JSON decode errors, with the raw body.
  - Subscription not found → **lists the slugs actually available on the account** (or notes none were returned).
  - `update-check` returning no package data for the product ID.
- Fix a PHP 8.5 implicit-nullable deprecation (`?string $body`).

**`.github/actions/wccom-package/action.yml`**
- Run the script and check its exit code **before** writing the heredoc, so a failure produces a clean `::error::` and exit instead of an unterminated `$GITHUB_OUTPUT` block.

## Notes
This is purely diagnostics — it does not change behaviour on success. The original failing run still needs its underlying cause fixed (lapsed/missing WooCommerce.com subscription or invalid tokens); with this change a re-run will state exactly which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)